### PR TITLE
fix incorrect flag to set tilix working dir

### DIFF
--- a/nautilus_open_any_terminal/open_any_terminal_extension.py
+++ b/nautilus_open_any_terminal/open_any_terminal_extension.py
@@ -25,7 +25,7 @@ TERM_PARAMS = {"alacritty": "--working-directory ",
                "qterminal": "--workdir ",
                "terminator": "--working-directory=",
                "terminology": "--current-directory ",
-               "tilix": "-x ",
+               "tilix": "-w ",
                "xfce4-terminal": "--working-directory="}
 
 NEW_TAB_PARAMS = {"alacritty": None,


### PR DESCRIPTION
The tilx flag `-x` is for executing something, so launching tilix with this extension failed with an error message complaining that the directory was not an executable. `-w` is the right flag.