### PR TITLE
Fix typo in bad encoding definition

### DIFF
--- a/nautilus_open_any_terminal/open_any_terminal_extension.py
+++ b/nautilus_open_any_terminal/open_any_terminal_extension.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 # based on: https://github.com/gnunn1/tilix/blob/master/data/nautilus/open-tilix.py
 
 from gettext import gettext, textdomain

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# encoding: UTF-8
+# -*- coding: utf-8 -*-
 
 import glob
 import os


### PR DESCRIPTION
The coding definition is a local variable definition[1].  However, this uppercase `UTF-8`, makes MULE (Emacs) prevent saving this file.

[1] https://www.gnu.org/software/emacs/manual/html_node/emacs/Specifying-File-Variables.html).