### PR TITLE
Optimize install scripts

### DIFF
--- a/tools/update-extension-system.sh
+++ b/tools/update-extension-system.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 # Make the extension available to all users.
 #
@@ -19,33 +19,27 @@ LANGUAGEDIR=/usr/share/locale
 LANGUAGESRC=nautilus_open_any_terminal/locale
 LANGUAGEFILE=nautilus-open-any-terminal.mo
 
-bn=$(basename "$SRC")
-
 case "$1" in
     install)
         # copy nautilus files
-        mkdir -v -p "$TARGDIR"
-        chmod 0755 "$TARGDIR"
-        cp -v "$SRC" "$TARGDIR/$bn"
-        chmod -c 0644 "$TARGDIR/$bn"
+        install -Dvm644 "${SRC}" -t "${TARGDIR}"
         # copy language files
-        cd "$LANGUAGESRC" || exit
+        cd "${LANGUAGESRC}" || exit
         find . -name '*.po' | while read -r po_file;do
-            mo_file=$(echo "$po_file" | sed 's/\(.*\)\.po$/\1.mo/')
-            msgfmt -o "$mo_file" "$po_file"
+            msgfmt -o "${po_file%.po}.mo" "${po_file}"
         done
-        find . -name '*.mo' -exec cp -v --parents '{}' "$LANGUAGEDIR" \;
+        find . -name '*.mo' -exec cp -v --parents '{}' "${LANGUAGEDIR}" \;
         cd ../..
         find . -name '*.mo' -exec chmod -c 0644 '{}' \;
         # copy schema file
-        cp -v "$SCHEMASSRC/$SCHEMAFILE" "$SCHEMASDIR"
-        glib-compile-schemas $SCHEMASDIR
+        install -Dv "${SCHEMASSRC}/${SCHEMAFILE}" -t "${SCHEMASDIR}"
+        glib-compile-schemas "${SCHEMASDIR}"
         ;;
     uninstall)
-        rm -vf "$TARGDIR/$bn"
-        find $LANGUAGEDIR -type f -name "$LANGUAGEFILE" -exec rm -vf '{}' \;
-        rm -vf $SCHEMASDIR/$SCHEMAFILE
-        glib-compile-schemas $SCHEMASDIR
+        rm -vf "${TARGDIR}/$(basename "${SRC}")"
+        find "${LANGUAGEDIR}" -type f -name "${LANGUAGEFILE}" -exec rm -vf '{}' \;
+        rm -vf "${SCHEMASDIR}/${SCHEMAFILE}"
+        glib-compile-schemas "${SCHEMASDIR}"
         ;;
     *)
         echo >&2 "usage: $0 {install|uninstall}"

--- a/tools/update-extension-user.sh
+++ b/tools/update-extension-user.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 # Make the extension available to the current user.
 
@@ -13,39 +13,29 @@ LANGUAGEDIR=~/.local/share/locale
 LANGUAGESRC=nautilus_open_any_terminal/locale
 LANGUAGEFILE=nautilus-open-any-terminal.mo
 
-bn=$(basename "$SRC")
-
 case "$1" in
     install)
         # copy nautilus files
-        mkdir -v -p "$TARGDIR"
-        chmod 0755 "$TARGDIR"
-        cp -v "$SRC" "$TARGDIR/$bn"
-        chmod -c 0644 "$TARGDIR/$bn"
+        install -Dvm644 "${SRC}" -t "${TARGDIR}"
         # copy language files
-        if ! [ -e "$LANGUAGEDIR" ];then
-            mkdir -v -p "$LANGUAGEDIR"
-        fi
+        mkdir -vp "${LANGUAGEDIR}"
+        oldpwd="${PWD}"
         cd "$LANGUAGESRC" || exit
         find . -name '*.po' | while read -r po_file;do
-            mo_file=$(echo "$po_file" | sed 's/\(.*\)\.po$/\1.mo/')
-            msgfmt -o "$mo_file" "$po_file"
+            msgfmt -o "${po_file%.po}.mo" "${po_file}"
         done
-        find . -name '*.mo' -exec cp -v --parents '{}' "$LANGUAGEDIR" \;
-        cd ../..
+        find . -name '*.mo' -exec cp -v --parents '{}' "${LANGUAGEDIR}" \;
+        cd "${oldpwd}" || exit
         find . -name '*.mo' -exec chmod -c 0644 '{}' \;
         # copy schema file
-        if ! [ -e "$SCHEMASDIR" ];then
-            mkdir -v -p "$SCHEMASDIR"
-        fi
-        cp -v "$SCHEMASSRC/$SCHEMAFILE" "$SCHEMASDIR"
-        glib-compile-schemas $SCHEMASDIR
+        install -Dv "${SCHEMASSRC}/${SCHEMAFILE}" -t "${SCHEMASDIR}"
+        glib-compile-schemas "${SCHEMASDIR}"
         ;;
     uninstall)
-        rm -vf "$TARGDIR/$bn"
-        find $LANGUAGEDIR -type f -name "$LANGUAGEFILE" -exec rm -vf '{}' \;
-        rm -vf $SCHEMASDIR/$SCHEMAFILE
-        glib-compile-schemas $SCHEMASDIR
+        rm -vf "${TARGDIR}/$(basename "${SRC}")"
+        find "${LANGUAGEDIR}" -type f -name "${LANGUAGEFILE}" -exec rm -vf '{}' \;
+        rm -vf "${SCHEMASDIR}/${SCHEMAFILE}"
+        glib-compile-schemas "${SCHEMASDIR}"
         ;;
     *)
         echo >&2 "usage: $0 {install|uninstall}"


### PR DESCRIPTION
- Use `install` instead of `mkdir`/`cp`/`chmod` when possible
- Avoid spawning new processes