### PR TITLE
prepare release 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nautilus-open-any-terminal"
-version = "0.4.0"
+version = "0.5.0"
 description = "an extension for nautilus, which adds an context-entry for opening other terminal emulators than gnome-terminal."
 authors = [
     {name = "Felix Buehler", email = "account@buehler.rocks"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [ "nautilus", "extension", "terminal", "gnome"]
 
 [build-system]
 requires = [
-    "setuptools>=69.0.3",
+    "setuptools",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
prepare for 0.5.0 release
`setuptools` is too up-to-date. No distro will have this available. But not much changed, so i guess we can leave it out.