### PR TITLE
Add caja support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ else
 export PREFIX ?= ${HOME}/.local
 endif
 
+FILE_MANAGERS ?= nautilus caja
 EXTSRC := nautilus_open_any_terminal/nautilus_open_any_terminal.py
-EXTDEST := $(PREFIX)/share/nautilus-python/extensions
 SCHEMASRC := nautilus_open_any_terminal/schemas/com.github.stunkymonkey.nautilus-open-any-terminal.gschema.xml
 SCHEMADEST := $(PREFIX)/share/glib-2.0/schemas
 
@@ -19,7 +19,9 @@ clean:
 	$(MAKE) -C $(LOCALES) clean
 
 install:
-	install -Dm644 $(EXTSRC) -t $(EXTDEST)
+	for fm in $(FILE_MANAGERS); do \
+	    install -Dm644 $(EXTSRC) -t $(PREFIX)/share/$${fm}-python/extensions; \
+	done
 	$(MAKE) -C $(LOCALES) install
 	install -Dm644 $(SCHEMASRC) -t $(SCHEMADEST)
 
@@ -27,9 +29,9 @@ schema:
 	glib-compile-schemas $(SCHEMADEST)
 
 uninstall:
-	$(RM) $(EXTDEST)/$$(basename $(EXTSRC))
+	$(RM) $(foreach fm,$(FILE_MANAGERS),$(PREFIX)/share/$(fm)-python/extensions/$(basename $(EXTSRC)))
 	$(MAKE) -C $(LOCALES) uninstall
-	$(RM) $(SCHEMADEST)/$$(basename $(SCHEMASRC))
+	$(RM) $(SCHEMADEST)/$(basename $(SCHEMASRC))
 
 
 .PHONY: build clean install schema uninstall

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ else
 export PREFIX ?= ${HOME}/.local
 endif
 
-FILE_MANAGERS ?= nautilus caja
 EXTSRC := nautilus_open_any_terminal/nautilus_open_any_terminal.py
 SCHEMASRC := nautilus_open_any_terminal/schemas/com.github.stunkymonkey.nautilus-open-any-terminal.gschema.xml
 SCHEMADEST := $(PREFIX)/share/glib-2.0/schemas
 
+FILE_MANAGERS := nautilus caja
+INSTALLS := $(patsubst %,install-%,$(FILE_MANAGERS))
+UNINSTALLS := $(patsubst %,uninstall-%,$(FILE_MANAGERS))
 
 build:
 	$(MAKE) -C $(LOCALES)
@@ -18,20 +20,26 @@ build:
 clean:
 	$(MAKE) -C $(LOCALES) clean
 
-install:
-	for fm in $(FILE_MANAGERS); do \
-	    install -Dm644 $(EXTSRC) -t $(PREFIX)/share/$${fm}-python/extensions; \
-	done
-	$(MAKE) -C $(LOCALES) install
-	install -Dm644 $(SCHEMASRC) -t $(SCHEMADEST)
-
 schema:
 	glib-compile-schemas $(SCHEMADEST)
 
-uninstall:
-	$(RM) $(foreach fm,$(FILE_MANAGERS),$(PREFIX)/share/$(fm)-python/extensions/$(basename $(EXTSRC)))
+install: $(INSTALLS)
+
+$(INSTALLS): install-common
+	install -Dm644 $(EXTSRC) -t $(PREFIX)/share/$(patsubst install-%,%-python,$@)/extensions
+
+install-common:
+	$(MAKE) -C $(LOCALES) install
+	install -Dm644 $(SCHEMASRC) -t $(SCHEMADEST)
+
+uninstall: $(UNINSTALLS)
+
+$(UNINSTALLS): uninstall-common
+	$(RM) $(PREFIX)/share/$(patsubst uninstall-%,%-python,$@)/extensions/$(notdir $(EXTSRC))
+
+uninstall-common:
 	$(MAKE) -C $(LOCALES) uninstall
-	$(RM) $(SCHEMADEST)/$(basename $(SCHEMASRC))
+	$(RM) $(SCHEMADEST)/$(notdir $(SCHEMASRC))
 
 
-.PHONY: build clean install schema uninstall
+.PHONY: build clean schema install $(INSTALLS) install-common uninstall $(UNINSTALLS) uninstall-common

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ is an extension for nautilus, which adds an context-entry for opening other term
 
 ![screenshot](./screenshot.png)
 
+## Supported file managers
+- Nautilus
+- Caja
+
 ## Supported Terminal Emulators
 
 Right now the plugin is limited to these terminal emulators. If one is missing please open an issue.
@@ -82,6 +86,13 @@ make
 
 make install schema      # User install
 sudo make install schema # System install
+```
+By default, this extension is installed to extension directories of all
+supported file managers. This can be changed by setting `FILE_MANAGERS`
+
+```sh
+make FILE_MANAGERS="nautilus" install schema # Install nautilus only
+FILE_MANAGERS="caja" make install schema # Install caja only
 ```
 
 ### restart nautilus

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ make
 make install schema      # User install
 sudo make install schema # System install
 ```
-By default, this extension is installed to extension directories of all
-supported file managers. This can be changed by setting `FILE_MANAGERS`
+`install` installs this extension to extension directories of all supported file
+managers. To avoid this, use `install-nautilus` or `install-caja` instead.
 
 ```sh
-make FILE_MANAGERS="nautilus" install schema # Install nautilus only
-FILE_MANAGERS="caja" make install schema # Install caja only
+make install-nautilus schema # Install nautilus only
+make install-caja schema # Install caja only
 ```
 
 ### restart nautilus

--- a/nautilus_open_any_terminal/locale/Makefile
+++ b/nautilus_open_any_terminal/locale/Makefile
@@ -11,11 +11,12 @@ $(MO_FILES): %.mo: %.po
 	msgfmt -o $@ $^
 
 install:
-	$(foreach lang,$(LANGUAGES),install -Dm644 $(lang).mo \
-	          $(PREFIX)/share/locale/$(lang)/LC_MESSAGES/$(MO_NAME);)
+	for lang in $(LANGUAGES); do \
+	    install -Dm644 $${lang}.mo $(PREFIX)/share/locale/$${lang}/LC_MESSAGES/$(MO_NAME); \
+	done
 
 uninstall:
-	$(foreach lang,$(LANGUAGES),$(RM) $(PREFIX)/share/locale/$(lang)/LC_MESSAGES/$(MO_NAME);)
+	$(RM) $(foreach lang,$(LANGUAGES),$(PREFIX)/share/locale/$(lang)/LC_MESSAGES/$(MO_NAME))
 
 clean:
 	$(RM) *.mo

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ from setuptools.command.build_py import build_py
 from setuptools.command.install import install
 from setuptools.command.sdist import sdist
 
+FILE_MANAGERS = ["nautilus", "caja"]
+
 
 def build_mo():
     for po_path in Path("nautilus_open_any_terminal/locale").glob("*.po"):
@@ -32,10 +34,11 @@ class InstallCommand(install):
         # Install Nautilus Python extension
         print("== Installing Nautilus Python extension")
         src_file = Path("nautilus_open_any_terminal/nautilus_open_any_terminal.py")
-        dst_dir = Path(self.install_data) / "share/nautilus-python/extensions"
-        dst_dir.mkdir(parents=True, exist_ok=True)
-        dst_file = dst_dir / src_file.name
-        self.copy_file(src_file, dst_file)
+        for fm in FILE_MANAGERS:
+            dst_dir = Path(self.install_data) / f"share/{fm}-python/extensions"
+            dst_dir.mkdir(parents=True, exist_ok=True)
+            dst_file = dst_dir / src_file.name
+            self.copy_file(src_file, dst_file)
         print("== Done!")
 
         # Install language files


### PR DESCRIPTION
The extension already works with caja, the only thing left is to update the installation scripts. Caja expects extensions in `/usr/share/caja-python`, should we install to both directories or somehow let the user pick which file managers should be installed?

Fixes #40