### PR TITLE
Rename Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Right now the plugin is limited to these terminal emulators. If one is missing p
 - `konsole`
 - `mate-terminal`
 - `mlterm`
-- `prompt`
+- `ptyxis`
 - `qterminal`
 - `rio`
 - `sakura`

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -63,12 +63,12 @@ TERMINALS = {
     "konsole": Terminal("Konsole", new_tab_arguments=["--new-tab"]),
     "mate-terminal": Terminal("Mate Terminal", new_tab_arguments=["--tab"]),
     "mlterm": Terminal("Mlterm"),
-    "prompt": Terminal(
-        "Prompt",
+    "ptyxis": Terminal(
+        "Ptyxis",
         command_arguments=["-x"],
         new_tab_arguments=["--tab"],
         new_window_arguments=["--new-window"],
-        flatpak_package="org.gnome.Prompt",
+        flatpak_package="org.gnome.Ptyxis",
     ),
     "qterminal": Terminal("QTerminal"),
     "rio": Terminal("Rio"),


### PR DESCRIPTION
Due to trademark issues Prompt has been renamed, this updates the name and path to match. 