### PR TITLE
Enable local shell in remote directories

### DIFF
--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -316,23 +316,39 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
                 uri = file_.get_uri()
                 item = FileManager.MenuItem(
                     name="OpenTerminal::open_remote_item",
-                    label=_("Open Remote {}").format(terminal_data.name),
+                    label=_("Open In Remote {}").format(terminal_data.name),
                     tip=_("Open Remote {} In {}").format(terminal_data.name, uri),
                 )
                 item.connect("activate", self._menu_activate_cb, file_, True)
                 items.append(item)
-            # Let wezterm handle opening a local terminal
-            if terminal == "wezterm" and flatpak == "off":
-                return items
 
-            filename = file_.get_name()
-            item = FileManager.MenuItem(
-                name="OpenTerminal::open_file_item",
-                label=_("Open In {}").format(terminal_data.name),
-                tip=_("Open {} In {}").format(terminal_data.name, filename),
-            )
-            item.connect("activate", self._menu_activate_cb, file_, False)
-            items.append(item)
+                # Let wezterm handle opening a local terminal
+                if terminal == "wezterm" and flatpak == "off":
+                    return items
+
+                filename = file_.get_name()
+                item = FileManager.MenuItem(
+                    name="OpenTerminal::open_file_item",
+                    label=_("Open In Local {}").format(terminal_data.name),
+                    tip=_("Open Local {} In {}").format(terminal_data.name, filename),
+                )
+                item.connect("activate", self._menu_activate_cb, file_, False)
+                items.append(item)
+
+            else:
+
+                # Let wezterm handle opening a local terminal
+                if terminal == "wezterm" and flatpak == "off":
+                    return items
+
+                filename = file_.get_name()
+                item = FileManager.MenuItem(
+                    name="OpenTerminal::open_file_item",
+                    label=_("Open In {}").format(terminal_data.name),
+                    tip=_("Open {} In {}").format(terminal_data.name, filename),
+                )
+                item.connect("activate", self._menu_activate_cb, file_, False)
+                items.append(item)
 
         return items
 
@@ -352,17 +368,31 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
             )
             item.connect("activate", self._menu_activate_cb, file_, True)
             items.append(item)
-        # Let wezterm handle opening a local terminal
-        if terminal == "wezterm" and flatpak == "off":
-            return items
 
-        item = FileManager.MenuItem(
-            name="OpenTerminal::open_bg_file_item",
-            label=_("Open {} Here").format(terminal_data.name),
-            tip=_("Open {} In This Directory").format(terminal_data.name),
-        )
-        item.connect("activate", self._menu_activate_cb, file_, False)
-        items.append(item)
+            # Let wezterm handle opening a local terminal
+            if terminal == "wezterm" and flatpak == "off":
+                return items
+
+            item = FileManager.MenuItem(
+                name="OpenTerminal::open_bg_file_item",
+                label=_("Open Local {} Here").format(terminal_data.name),
+                tip=_("Open Local {} In This Directory").format(terminal_data.name),
+            )
+            item.connect("activate", self._menu_activate_cb, file_, False)
+            items.append(item)
+        else:
+
+            # Let wezterm handle opening a local terminal
+            if terminal == "wezterm" and flatpak == "off":
+                return items
+
+            item = FileManager.MenuItem(
+                name="OpenTerminal::open_bg_file_item",
+                label=_("Open {} Here").format(terminal_data.name),
+                tip=_("Open {} In This Directory").format(terminal_data.name),
+            )
+            item.connect("activate", self._menu_activate_cb, file_, False)
+            items.append(item)
         return items
 
 

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -340,7 +340,6 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
                 items.append(item)
 
             else:
-
                 # Let wezterm handle opening a local terminal
                 if terminal == "wezterm" and flatpak == "off":
                     return items
@@ -385,7 +384,6 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
             item.connect("activate", self._menu_activate_cb, file_, False)
             items.append(item)
         else:
-
             # Let wezterm handle opening a local terminal
             if terminal == "wezterm" and flatpak == "off":
                 return items

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -312,13 +312,11 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
         file_ = files[0]
 
         if file_.is_directory():
-            local_str = ""
             if file_.get_uri_scheme() in REMOTE_URI_SCHEME:
-                local_str = "Local "
                 uri = file_.get_uri()
                 item = FileManager.MenuItem(
                     name="OpenTerminal::open_remote_item",
-                    label=_("Open In Remote {}").format(terminal_data.name),
+                    label=_("Open Remote {}").format(terminal_data.name),
                     tip=_("Open Remote {} In {}").format(terminal_data.name, uri),
                 )
                 item.connect("activate", self._menu_activate_cb, file_, True)
@@ -330,8 +328,8 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
             filename = file_.get_name()
             item = FileManager.MenuItem(
                 name="OpenTerminal::open_file_item",
-                label=_("Open In {}{}").format(local_str, terminal_data.name),
-                tip=_("Open {}{} In {}").format(local_str, terminal_data.name, filename),
+                label=_("Open In {}").format(terminal_data.name),
+                tip=_("Open {} In {}").format(terminal_data.name, filename),
             )
             item.connect("activate", self._menu_activate_cb, file_, False)
             items.append(item)
@@ -346,9 +344,7 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
         file_ = args[-1]
 
         items = []
-        local_str = ""
         if file_.get_uri_scheme() in REMOTE_URI_SCHEME:
-            local_str = "Local "
             item = FileManager.MenuItem(
                 name="OpenTerminal::open_bg_remote_item",
                 label=_("Open Remote {} Here").format(terminal_data.name),
@@ -362,8 +358,8 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
 
         item = FileManager.MenuItem(
             name="OpenTerminal::open_bg_file_item",
-            label=_("Open {}{} Here").format(local_str, terminal_data.name),
-            tip=_("Open {}{} In This Directory").format(local_str, terminal_data.name),
+            label=_("Open {} Here").format(terminal_data.name),
+            tip=_("Open {} In This Directory").format(terminal_data.name),
         )
         item.connect("activate", self._menu_activate_cb, file_, False)
         items.append(item)

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -1,4 +1,5 @@
 """nautilus extension: nautilus_open_any_terminal"""
+
 # based on: https://github.com/gnunn1/tilix/blob/master/data/nautilus/open-tilix.py
 
 import ast
@@ -168,6 +169,7 @@ def distro_id() -> set[str]:
     if id_like := os_release.get("ID_LIKE"):
         ids.extend(id_like.split(" "))
     return set(ids)
+
 
 def open_remote_terminal_in_uri(uri: str):
     """Open a new remote terminal"""

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -310,11 +310,13 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
         file_ = files[0]
 
         if file_.is_directory():
+            local_str = ""
             if file_.get_uri_scheme() in REMOTE_URI_SCHEME:
+                local_str = "Local "
                 uri = file_.get_uri()
                 item = FileManager.MenuItem(
                     name="OpenTerminal::open_remote_item",
-                    label=_("Open Remote {}").format(terminal_data.name),
+                    label=_("Open In Remote {}").format(terminal_data.name),
                     tip=_("Open Remote {} In {}").format(terminal_data.name, uri),
                 )
                 item.connect("activate", self._menu_activate_cb, file_, True)
@@ -326,8 +328,8 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
             filename = file_.get_name()
             item = FileManager.MenuItem(
                 name="OpenTerminal::open_file_item",
-                label=_("Open In {}").format(terminal_data.name),
-                tip=_("Open {} In {}").format(terminal_data.name, filename),
+                label=_("Open In {}{}").format(local_str, terminal_data.name),
+                tip=_("Open {}{} In {}").format(local_str, terminal_data.name, filename),
             )
             item.connect("activate", self._menu_activate_cb, file_, False)
             items.append(item)
@@ -342,7 +344,9 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
         file_ = args[-1]
 
         items = []
+        local_str = ""
         if file_.get_uri_scheme() in REMOTE_URI_SCHEME:
+            local_str = "Local "
             item = FileManager.MenuItem(
                 name="OpenTerminal::open_bg_remote_item",
                 label=_("Open Remote {} Here").format(terminal_data.name),
@@ -356,8 +360,8 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
 
         item = FileManager.MenuItem(
             name="OpenTerminal::open_bg_file_item",
-            label=_("Open {} Here").format(terminal_data.name),
-            tip=_("Open {} In This Directory").format(terminal_data.name),
+            label=_("Open {}{} Here").format(local_str, terminal_data.name),
+            tip=_("Open {}{} In This Directory").format(local_str, terminal_data.name),
         )
         item.connect("activate", self._menu_activate_cb, file_, False)
         items.append(item)

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -119,6 +119,7 @@ flatpak = FLATPAK_PARMS[0]
 
 GSETTINGS_PATH = "com.github.stunkymonkey.nautilus-open-any-terminal"
 GSETTINGS_KEYBINDINGS = "keybindings"
+GSETTINGS_BIND_REMOTE = "bind-remote"
 GSETTINGS_TERMINAL = "terminal"
 GSETTINGS_NEW_TAB = "new-tab"
 GSETTINGS_FLATPAK = "flatpak"
@@ -278,7 +279,10 @@ if API_VERSION in ("3.0", "2.0"):
                 self._create_accel_group()
 
         def _open_terminal(self, *_args):
-            open_local_terminal_in_uri(self._uri)
+            if _gsettings.get_boolean(GSETTINGS_BIND_REMOTE):
+                open_local_terminal_in_uri(self._uri)
+            else:
+                open_remote_terminal_in_uri(self._uri)
 
         def get_widget(self, uri, window):
             """follows uri and sets the correct window"""

--- a/nautilus_open_any_terminal/schemas/com.github.stunkymonkey.nautilus-open-any-terminal.gschema.xml
+++ b/nautilus_open_any_terminal/schemas/com.github.stunkymonkey.nautilus-open-any-terminal.gschema.xml
@@ -11,6 +11,11 @@
       <summary>Keyboard shortcut used in Nautilus for Open Here extension</summary>
       <description></description>
     </key>
+    <key name="bind-remote" type="b">
+      <default>false</default>
+      <summary>Whether the keyboard shortcut opens a remote terminal in remote directories</summary>
+      <description></description>
+    </key>
     <key name="terminal" type="s">
       <default>'gnome-terminal'</default>
       <summary>Terminal used in Nautilus for Open Here extension</summary>


### PR DESCRIPTION
Thanks for this nice extension!

When browsing a remote location in nautilus, the native open terminal context menu option gives you the option to open a local or remote terminal:

![screeny](https://github.com/Stunkymonkey/nautilus-open-any-terminal/assets/18050721/a6e20855-d39f-4748-bff4-30aa6e2059ba)

I find this pretty useful so this pull request attempts to replicate this behavior within nautilus-open-any-terminal.

If this feature is something that you would consider merging I am happy to make any required changes. I think it could be cleaned up a bit at least. 