### PR TITLE
Make remote terminal open as a login shell

### DIFF
--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -188,7 +188,7 @@ def open_remote_terminal_in_uri(uri: str):
         cmd.append("-p")
         cmd.append(str(result.port))
 
-    cmd.extend(["cd", shlex.quote(unquote(result.path)), ";", "exec", "$SHELL", "-l"])
+    cmd.extend(["cd", shlex.quote(unquote(result.path)), ";", "exec", "-a", "-$SHELL", "$SHELL"])
 
     Popen(cmd)  # pylint: disable=consider-using-with
 

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -188,7 +188,7 @@ def open_remote_terminal_in_uri(uri: str):
         cmd.append("-p")
         cmd.append(str(result.port))
 
-    cmd.extend(["cd", shlex.quote(unquote(result.path)), ";", "exec", "$SHELL"])
+    cmd.extend(["cd", shlex.quote(unquote(result.path)), ";", "exec", "$SHELL", "-l"])
 
     Popen(cmd)  # pylint: disable=consider-using-with
 

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -188,7 +188,7 @@ def open_remote_terminal_in_uri(uri: str):
         cmd.append("-p")
         cmd.append(str(result.port))
 
-    cmd.extend(["cd", shlex.quote(unquote(result.path)), ";", "exec", "-a", "-$SHELL", "$SHELL"])
+    cmd.extend(["cd", shlex.quote(unquote(result.path)), ";", "exec", "$SHELL", "-l"])
 
     Popen(cmd)  # pylint: disable=consider-using-with
 


### PR DESCRIPTION
The --login/-l flag signals that this is a login shell.

Currently without this flag environment files like `.profile` or `/etc/profile` are not sourced, which is unexpected when opening a new terminal. 
