### PR TITLE
Add support for Ghostty

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Right now the plugin is limited to these terminal emulators. If one is missing p
 - `cool-retro-term`
 - `deepin-terminal`
 - `foot`/`footclient`
+- `ghostty`
 - `gnome-terminal`
 - `guake`
 - `hyper`

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -61,6 +61,7 @@ TERMINALS = {
     "deepin-terminal": Terminal("Deepin Terminal"),
     "foot": Terminal("Foot"),
     "footclient": Terminal("FootClient"),
+    "ghostty": Terminal("Ghostty"),
     "gnome-terminal": Terminal("Terminal", new_tab_arguments=["--tab"]),
     "guake": Terminal("Guake", workdir_arguments=["--show", "--new-tab"]),
     "hyper": Terminal("Hyper"),


### PR DESCRIPTION
Adds support for [Ghostty](https://mitchellh.com/ghostty). The new tab option doesn't work but I don't think ghostty supports it at all as far as I can tell. 