### PR TITLE
Update stable Ptyxis flatpak package name

### DIFF
--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -82,7 +82,7 @@ TERMINALS = {
         command_arguments=["-x"],
         new_tab_arguments=["--tab"],
         new_window_arguments=["--new-window"],
-        flatpak_package="org.gnome.Ptyxis",
+        flatpak_package="app.devsuite.Ptyxis",
     ),
     "ptyxis-nightly": Terminal(
         "Ptyxis",


### PR DESCRIPTION
Ptyxis recently got a [stable release on Flathub](https://flathub.org/apps/app.devsuite.Ptyxis) as `app.devsuite.Ptyxis` instead of `org.gnome.Ptyxis`, so its flatpak package name should be updated to reflect this.

`ptyxis-nightly` is still available in the GNOME nightly repository as `org.gnome.Ptyxis.Devel`, so the nightly package name remains unchanged.