### PR TITLE
Add custom terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ is an extension for nautilus, which adds an context-entry for opening other term
 
 ## Supported Terminal Emulators
 
-Right now the plugin is limited to these terminal emulators. If one is missing please open an issue.
+The following terminal emulators are fully supported. PRs for other terminals
+are welcome!
 
 - `alacritty`
 - `blackbox`
@@ -47,6 +48,9 @@ Right now the plugin is limited to these terminal emulators. If one is missing p
 - `wezterm`
 - `xfce4-terminal`
 - `xterm`/`uxterm`
+
+Additionally, the terminal can be set to `custom`, which allows you to set
+custom commands for opening a local or remote terminal via dconf.
 
 ## Installing
 

--- a/nautilus_open_any_terminal/schemas/com.github.stunkymonkey.nautilus-open-any-terminal.gschema.xml
+++ b/nautilus_open_any_terminal/schemas/com.github.stunkymonkey.nautilus-open-any-terminal.gschema.xml
@@ -21,6 +21,22 @@
       <summary>Terminal used in Nautilus for Open Here extension</summary>
       <description></description>
     </key>
+    <key name="custom-local-command" type="s">
+      <default>""</default>
+      <summary>Command that opens a local terminal if terminal is set to "custom"</summary>
+      <description>
+        Every occurence of "%s" in the command will be replaced with the path where the terminal should be opened.
+        Any number of "%s" in the command are valid, including 0.
+      </description>
+    </key>
+    <key name="custom-remote-command" type="s">
+      <default>""</default>
+      <summary>Command that opens a remote terminal if terminal is set to "custom"</summary>
+      <description>
+        Every occurence of "%s" in the command will be replaced with an ssh command that connects to the remote server.
+        There should be at least 1 "%s" in the command.
+      </description>
+    </key>
     <key name="use-generic-terminal-name" type="b">
       <default>false</default>
       <summary>Whether to display specific or generic terminal name.</summary>


### PR DESCRIPTION
This lets users use terminal emulators from outside the predefined list by manually specifying commands for opening a local/remote terminal.