### PR TITLE
Update nixpkgs installation instructions to reflect module changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,9 @@ programs.nautilus-open-any-terminal = {
   terminal = "kitty";
 };
 
-environment = {
-  sessionVariables.NAUTILUS_4_EXTENSION_DIR = "${pkgs.gnome.nautilus-python}/lib/nautilus/extensions-4";
-  pathsToLink = [
-    "/share/nautilus-python/extensions"
-  ];
-
-  systemPackages = with pkgs; [
-    gnome.nautilus
-    gnome.nautilus-python
-  ];
-};
+environment.systemPackages = with pkgs; [
+  nautilus
+];
 ```
 
 ### From PYPI [![PyPI package](https://repology.org/badge/version-for-repo/pypi/nautilus-open-any-terminal.svg)](https://repology.org/project/nautilus-open-any-terminal/versions)


### PR DESCRIPTION
I recently added the extra options specified by the readme into the NixOS module for nautilus-open-any-terminal (relevant PR linked [here](https://github.com/NixOS/nixpkgs/pull/342104)). This was PRed into unstable, so it won't work on nixos-24.05 `yet`. However, when the new version comes out in November, this README can be updated to reflect the simpler installation changes. 