### PR TITLE
Remove Hyper support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ are welcome!
 - `ghostty`
 - `gnome-terminal`
 - `guake`
-- `hyper`
 - `kermit`
 - `kgx` (GNOME Console)
 - `kitty`

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -74,7 +74,6 @@ TERMINALS = {
     "ghostty": Terminal("Ghostty"),
     "gnome-terminal": Terminal("Terminal", new_tab_arguments=["--tab"]),
     "guake": Terminal("Guake", workdir_arguments=["--show", "--new-tab"]),
-    "hyper": Terminal("Hyper"),
     "kermit": Terminal("Kermit"),
     "kgx": Terminal("Console", new_tab_arguments=["--tab"]),
     "kitty": Terminal("kitty"),


### PR DESCRIPTION
Hyper doesn't either preserve parent process CWD or expose any command line flags for opening in a different path. This makes it impossible to support by this project.

Closes #190 