### PR TITLE
chore: Update warp terminal open_local_terminal_in_uri functionality

### DIFF
--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -114,7 +114,10 @@ TERMINALS = {
     "urxvt": Terminal("rxvt-unicode"),
     "urxvtc": Terminal("urxvtc"),
     "uxterm": Terminal("UXTerm"),
-    "warp": Terminal("warp"),
+    "warp": Terminal(
+        "Warp",
+        new_tab_arguments=["--virtual-arg-for-tabs"],  # This is just to indicate tab support
+    ),
     "wezterm": Terminal(
         "Wez's Terminal Emulator",
         workdir_arguments=["--cwd"],
@@ -235,9 +238,12 @@ def open_local_terminal_in_uri(uri: str):
     result = urlparse(uri)
     cmd = terminal_cmd.copy()
     if terminal == "warp":
-        Popen(  # pylint: disable=consider-using-with
-            ["xdg-open", f'warp://action/new_{"tab" if new_tab else "window"}?path={result.path}']
-        )
+        # Force new_tab to be considered even without traditional tab arguments
+        action_type = "tab" if _gsettings.get_boolean(GSETTINGS_NEW_TAB) else "window"
+        Popen([
+            "xdg-open",
+            f'warp://action/new_{action_type}?path={result.path}'
+        ])
         return
 
     filename = unquote(result.path)

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -239,11 +239,9 @@ def open_local_terminal_in_uri(uri: str):
     cmd = terminal_cmd.copy()
     if terminal == "warp":
         # Force new_tab to be considered even without traditional tab arguments
-        action_type = "tab" if _gsettings.get_boolean(GSETTINGS_NEW_TAB) else "window"
-        Popen([
-            "xdg-open",
-            f'warp://action/new_{action_type}?path={result.path}'
-        ])
+        Popen(  # pylint: disable=consider-using-with
+            ["xdg-open", f"warp://action/new_{"tab" if new_tab else "window"}?path={result.path}"]
+        )
         return
 
     filename = unquote(result.path)


### PR DESCRIPTION
## Problem

After installing https://github.com/Stunkymonkey/nautilus-open-any-terminal/releases/tag/0.6.0 from .deb file on ubuntu 24.04.1 LTS i set terminal to `warp` via `dconf-editor` and it did not work out of box for nautilus file manager on my setup. 

To be more specific, it did not work with adding new tabs to the terminal, only new windows opened, despite the setup for `tabs` in `dconf-editor`.
I had to pull sources & update `open_local_terminal_in_uri` functionality a little.