### PR TITLE
Add Debian's version of Black box

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following terminal emulators are fully supported. PRs for other terminals
 are welcome!
 
 - `alacritty`
-- `blackbox`
+- `blackbox` ( use `blackbox-terminal` for Debian)
 - `bobcat`
 - `cool-retro-term`
 - `contour`

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -61,6 +61,11 @@ TERMINALS = {
         command_arguments=["-c"],
         flatpak_package="com.raggesilver.BlackBox",
     ),
+    "blackbox-terminal": Terminal(
+        "Black Box",
+        workdir_arguments=["--working-directory"],
+        command_arguments=["-c"],
+    ),    
     "bobcat": Terminal(
         "Bobcat",
         workdir_arguments=["--working-dir"],


### PR DESCRIPTION
Debian renames the Black Box binary to https://salsa.debian.org/debian/blackbox-terminal/-/blob/debian/debian/rules?ref_type=heads#L14

This PR adds a configuration for Debian users.

- Maybe it is better to change the Terminal configuration to take a list of alias names for the binary.
- Why not custom? I was not able to pass in the current directory using a custom command. Did not investigate that further.