### PR TITLE
fix: gnome 49 import

### DIFF
--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -425,7 +425,7 @@ def set_terminal_args(*_args):
     print(f'open-any-terminal: terminal is set to "{terminal}" {new_tab_text} {flatpak_text}')
 
 
-if API_VERSION == "4.0":
+if API_VERSION in ["4.0", "4.1"]:
 
     class OpenAnyTerminalShortcutProvider(GObject.GObject, FileManager.MenuProvider):
         """Provide keyboard shortcuts for opening terminals in Nautilus."""
@@ -494,7 +494,7 @@ if API_VERSION == "4.0":
             normalized = Gtk.accelerator_name(key, mods)
             self.app.set_accels_for_action("app.open_any_terminal", [normalized])
 
-elif API_VERSION in ("3.0", "2.0"):
+elif API_VERSION in ["2.0", "3.0"]:
 
     class OpenAnyTerminalShortcutProviderLegacy(GObject.GObject, FileManager.LocationWidgetProvider):
         """Provide keyboard shortcuts for opening terminals in Nautilus/Caja."""


### PR DESCRIPTION
fix #242

blocked by: https://gitlab.gnome.org/GNOME/nautilus-python/-/issues/38 & https://gitlab.gnome.org/GNOME/nautilus-python/-/merge_requests/16/diffs