### PR TITLE
fix: Adapt to Nautilus 49 API changes

### DIFF
--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -425,7 +425,7 @@ def set_terminal_args(*_args):
     print(f'open-any-terminal: terminal is set to "{terminal}" {new_tab_text} {flatpak_text}')
 
 
-if API_VERSION == "4.0":
+if API_VERSION in ("4.0", "4.1"):
 
     class OpenAnyTerminalShortcutProvider(GObject.GObject, FileManager.MenuProvider):
         """Provide keyboard shortcuts for opening terminals in Nautilus."""


### PR DESCRIPTION
Nautilus 49 beta bumps the `gobject-introspection` API version from 4.0 to 4.1, which breaks compatibility with this extension.

This commit updates the code to be compatible with the new API version.

Close: #242

Note: A complete fix for a related bug is currently blocked by an upstream issue in the nautilus-python library.

See: https://gitlab.gnome.org/GNOME/nautilus-python/-/issues/38