### PR TITLE
Fix remote terminal for remote hosts without bash

### DIFF
--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -234,7 +234,7 @@ def ssh_command_from_uri(uri: str, *, is_directory: bool):
 
     target = shlex.quote(unquote(result.path))
     if is_directory:
-        cmd.extend(["cd", target, ";", "exec", "$SHELL", "-l"])
+        cmd.extend(["cd", target, ";", "exec", "${SHELL:-/bin/sh}", "-l"])
     else:
         cmd.extend(["exec", target])
 


### PR DESCRIPTION
Hi,

currently, when trying to open remote terminal on a remote host without bash (eg. alpine), the command fails with "file not found: bash". This patch uses $SHELL, if available and otherwise defaults to sh.

Cheers