### PR TITLE
Fix fedora43 nautilus49 crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ or for (user-wide) installation:
 glib-compile-schemas ~/.local/share/glib-2.0/schemas/
 ```
 
+**Note for Flatpak dconf-editor users:** If you're using the Flatpak version of dconf-editor, you need to install the schema system-wide (to `/usr/share/glib-2.0/schemas/`) for it to be visible in the GUI. Flatpak applications cannot access schemas in `~/.local/`. Use `sudo make install schema` for system-wide installation.
+
 ### via dconf-editor
 
 ![dconf-editor](dconf.png)

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -50,7 +50,7 @@ try:
                 API_VERSION = "3.0"
             except ImportError:
                 print("nautilus-open-any-terminal: ERROR - Could not import file manager. Extension disabled.")
-except Exception as e:
+except (ImportError, ValueError, AttributeError) as e:
     print(f"nautilus-open-any-terminal: ERROR during initialization: {e}")
 
 from gi.repository import Gio, GLib, GObject, Gtk  # noqa: E402 pylint: disable=wrong-import-position
@@ -580,7 +580,7 @@ if FileManager is not None:
                 gsettings_source = Gio.SettingsSchemaSource.get_default()
                 if gsettings_source and gsettings_source.lookup(GSETTINGS_PATH, True):
                     self._gsettings = Gio.Settings.new(GSETTINGS_PATH)
-            except Exception as e:
+            except GLib.Error as e:
                 print(
                     f"nautilus-open-any-terminal: Warning - Could not load GSettings: {e}"
                 )
@@ -657,7 +657,7 @@ try:
     else:
         print("nautilus-open-any-terminal: Warning - GSettings schema not found. Using default terminal.")
         terminal_cmd = ["gnome-terminal"]
-except Exception as e:
+except (GLib.Error, AttributeError) as e:
     print(f"nautilus-open-any-terminal: ERROR - Failed to initialize GSettings: {e}")
     print("nautilus-open-any-terminal: Using default terminal: gnome-terminal")
     terminal_cmd = ["gnome-terminal"]

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -286,7 +286,10 @@ def open_local_terminal_in_uri(uri: str):
     if terminal == "warp":
         # Force new_tab to be considered even without traditional tab arguments
         Popen(  # pylint: disable=consider-using-with
-            ["xdg-open", f"warp://action/new_{'tab' if new_tab else 'window'}?path={result.path}"]
+            [
+                "xdg-open",
+                f"warp://action/new_{'tab' if new_tab else 'window'}?path={result.path}",
+            ]
         )
         return
 
@@ -314,7 +317,11 @@ def executable_menu_item_id(*, remote: bool):
 
 
 def get_directory_menu_items(
-    file: FileManager.FileInfo, callback, *, foreground: bool, terminal_name: str | None = None  # type: ignore[name-defined]
+    file: FileManager.FileInfo,
+    callback,
+    *,
+    foreground: bool,
+    terminal_name: str | None = None,  # type: ignore[name-defined]
 ):
     items = []
     remote = file.get_uri_scheme() in REMOTE_URI_SCHEME
@@ -369,7 +376,9 @@ def get_directory_menu_items(
     return items
 
 
-def get_executable_menu_items(file: FileManager.FileInfo, callback, *, terminal_name: str | None = None):  # type: ignore[name-defined]
+def get_executable_menu_items(
+    file: FileManager.FileInfo, callback, *, terminal_name: str | None = None
+):  # type: ignore[name-defined]
     items = []
     remote = file.get_uri_scheme() in REMOTE_URI_SCHEME
     terminal_name = terminal_name or terminal_data.name
@@ -534,7 +543,9 @@ if FileManager is not None and API_VERSION in ("4.0", "4.1"):
 
 elif FileManager is not None and API_VERSION in ("3.0", "2.0"):
 
-    class OpenAnyTerminalShortcutProviderLegacy(GObject.GObject, FileManager.LocationWidgetProvider):  # type: ignore[name-defined]
+    class OpenAnyTerminalShortcutProviderLegacy(
+        GObject.GObject, FileManager.LocationWidgetProvider
+    ):  # type: ignore[name-defined]
         """Provide keyboard shortcuts for opening terminals in Nautilus/Caja."""
 
         def __init__(self):
@@ -632,12 +643,17 @@ if FileManager is not None:
 
             if file_.is_directory():
                 return get_directory_menu_items(
-                    file_, self._menu_dir_activate_cb, foreground=True, terminal_name=self._get_terminal_name()
+                    file_,
+                    self._menu_dir_activate_cb,
+                    foreground=True,
+                    terminal_name=self._get_terminal_name(),
                 )
 
             if is_executable(file_.get_location()):
                 return get_executable_menu_items(
-                    file_, self._menu_exe_activate_cb, terminal_name=self._get_terminal_name()
+                    file_,
+                    self._menu_exe_activate_cb,
+                    terminal_name=self._get_terminal_name(),
                 )
 
             return []
@@ -649,7 +665,10 @@ if FileManager is not None:
 
             file_ = args[-1]
             return get_directory_menu_items(
-                file_, self._menu_dir_activate_cb, foreground=False, terminal_name=self._get_terminal_name()
+                file_,
+                self._menu_dir_activate_cb,
+                foreground=False,
+                terminal_name=self._get_terminal_name(),
             )
 
 

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -47,9 +47,7 @@ try:
 
                 API_VERSION = "3.0"
             except ImportError:
-                print(
-                    "nautilus-open-any-terminal: ERROR - Could not import file manager. Extension disabled."
-                )
+                print("nautilus-open-any-terminal: ERROR - Could not import file manager. Extension disabled.")
                 FileManager = None
 except Exception as e:
     print(f"nautilus-open-any-terminal: ERROR during initialization: {e}")

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -312,7 +312,7 @@ def executable_menu_item_id(*, remote: bool):
 
 
 def get_directory_menu_items(
-    file: FileManager.FileInfo, callback, *, foreground: bool, terminal_name: str | None = None
+    file: FileManager.FileInfo, callback, *, foreground: bool, terminal_name: str | None = None  # type: ignore[name-defined]
 ):
     items = []
     remote = file.get_uri_scheme() in REMOTE_URI_SCHEME
@@ -365,7 +365,7 @@ def get_directory_menu_items(
     return items
 
 
-def get_executable_menu_items(file: FileManager.FileInfo, callback, *, terminal_name: str | None = None):
+def get_executable_menu_items(file: FileManager.FileInfo, callback, *, terminal_name: str | None = None):  # type: ignore[name-defined]
     items = []
     remote = file.get_uri_scheme() in REMOTE_URI_SCHEME
     terminal_name = terminal_name or terminal_data.name
@@ -459,7 +459,7 @@ def set_terminal_args(*_args):
 
 if FileManager is not None and API_VERSION in ("4.0", "4.1"):
 
-    class OpenAnyTerminalShortcutProvider(GObject.GObject, FileManager.MenuProvider):
+    class OpenAnyTerminalShortcutProvider(GObject.GObject, FileManager.MenuProvider):  # type: ignore[name-defined]
         """Provide keyboard shortcuts for opening terminals in Nautilus."""
 
         def __init__(self):
@@ -471,7 +471,7 @@ if FileManager is not None and API_VERSION in ("4.0", "4.1"):
                 self._gsettings = Gio.Settings.new(GSETTINGS_PATH)
                 self._setup_keybindings()
 
-        def get_background_items(self, current_folder: FileManager.FileInfo):
+        def get_background_items(self, current_folder: FileManager.FileInfo):  # type: ignore[name-defined]
             """Update current URI when folder changes."""
             if current_folder:
                 if current_folder.get_uri_scheme() in REMOTE_URI_SCHEME:
@@ -528,7 +528,7 @@ if FileManager is not None and API_VERSION in ("4.0", "4.1"):
 
 elif FileManager is not None and API_VERSION in ("3.0", "2.0"):
 
-    class OpenAnyTerminalShortcutProviderLegacy(GObject.GObject, FileManager.LocationWidgetProvider):
+    class OpenAnyTerminalShortcutProviderLegacy(GObject.GObject, FileManager.LocationWidgetProvider):  # type: ignore[name-defined]
         """Provide keyboard shortcuts for opening terminals in Nautilus/Caja."""
 
         def __init__(self):
@@ -570,7 +570,7 @@ elif FileManager is not None and API_VERSION in ("3.0", "2.0"):
 
 if FileManager is not None:
 
-    class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
+    class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):  # type: ignore[name-defined]
         """Provide context menu items for opening terminals in Nautilus."""
 
         def __init__(self):

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -26,26 +26,28 @@ try:
         except ValueError:
             require_version("Gtk", "3.0")
         from gi.repository import Nautilus
+
         FileManager = Nautilus
     elif (API_VERSION := get_required_version("Caja")) is not None:
         require_version("Gtk", "3.0")
         from gi.repository import Caja
+
         FileManager = Caja
     else:
-        print(
-            "nautilus-open-any-terminal: Warning - Could not detect file manager, trying fallback"
-        )
+        print("nautilus-open-any-terminal: Warning - Could not detect file manager, trying fallback")
         try:
             require_version("Gtk", "4.0")
         except ValueError:
             require_version("Gtk", "3.0")
         try:
             from gi.repository import Nautilus
+
             FileManager = Nautilus
             API_VERSION = "4.1"
         except ImportError:
             try:
                 from gi.repository import Caja
+
                 FileManager = Caja
                 API_VERSION = "3.0"
             except ImportError:
@@ -332,13 +334,14 @@ def get_directory_menu_items(
             LOCAL_TIP = _("Open Local {} in This Directory")
             tip = REMOTE_TIP.format(terminal_name)
 
-        item = FileManager.MenuItem(
-            name=directory_menu_item_id(foreground=foreground, remote=True),
-            label=REMOTE_LABEL.format(terminal_name),
-            tip=tip,
-        )
-        item.connect("activate", callback, file, True)
-        items.append(item)
+        if FileManager is not None:
+            item = FileManager.MenuItem(
+                name=directory_menu_item_id(foreground=foreground, remote=True),
+                label=REMOTE_LABEL.format(terminal_name),
+                tip=tip,
+            )
+            item.connect("activate", callback, file, True)
+            items.append(item)
     elif foreground:
         LOCAL_LABEL = _("Open in {}")
         LOCAL_TIP = _("Open {} in {}")
@@ -355,13 +358,14 @@ def get_directory_menu_items(
     else:
         tip = LOCAL_TIP.format(terminal_name)
 
-    item = FileManager.MenuItem(
-        name=directory_menu_item_id(foreground=foreground, remote=False),
-        label=LOCAL_LABEL.format(terminal_name),
-        tip=tip,
-    )
-    item.connect("activate", callback, file, False)
-    items.append(item)
+    if FileManager is not None:
+        item = FileManager.MenuItem(
+            name=directory_menu_item_id(foreground=foreground, remote=False),
+            label=LOCAL_LABEL.format(terminal_name),
+            tip=tip,
+        )
+        item.connect("activate", callback, file, False)
+        items.append(item)
     return items
 
 
@@ -377,25 +381,27 @@ def get_executable_menu_items(file: FileManager.FileInfo, callback, *, terminal_
         LOCAL_TIP = _("Execute {} in Local {}")
 
         tip = REMOTE_TIP.format(file.get_name(), terminal_name)
-        item = FileManager.MenuItem(
-            name=executable_menu_item_id(remote=True),
-            label=REMOTE_LABEL.format(terminal_name),
-            tip=tip,
-        )
-        item.connect("activate", callback, file, True)
-        items.append(item)
+        if FileManager is not None:
+            item = FileManager.MenuItem(
+                name=executable_menu_item_id(remote=True),
+                label=REMOTE_LABEL.format(terminal_name),
+                tip=tip,
+            )
+            item.connect("activate", callback, file, True)
+            items.append(item)
     else:
         LOCAL_LABEL = _("Execute in {}")
         LOCAL_TIP = _("Execute {} in {}")
 
     tip = LOCAL_TIP.format(file.get_name(), terminal_name)
-    item = FileManager.MenuItem(
-        name=executable_menu_item_id(remote=False),
-        label=LOCAL_LABEL.format(terminal_name),
-        tip=tip,
-    )
-    item.connect("activate", callback, file, False)
-    items.append(item)
+    if FileManager is not None:
+        item = FileManager.MenuItem(
+            name=executable_menu_item_id(remote=False),
+            label=LOCAL_LABEL.format(terminal_name),
+            tip=tip,
+        )
+        item.connect("activate", callback, file, False)
+        items.append(item)
     return items
 
 
@@ -581,9 +587,7 @@ if FileManager is not None:
                 if gsettings_source and gsettings_source.lookup(GSETTINGS_PATH, True):
                     self._gsettings = Gio.Settings.new(GSETTINGS_PATH)
             except GLib.Error as e:
-                print(
-                    f"nautilus-open-any-terminal: Warning - Could not load GSettings: {e}"
-                )
+                print(f"nautilus-open-any-terminal: Warning - Could not load GSettings: {e}")
 
         def _get_terminal_name(self):
             if self._gsettings and self._gsettings.get_boolean(GSETTINGS_USE_GENERIC_TERMINAL_NAME):
@@ -632,7 +636,9 @@ if FileManager is not None:
                 )
 
             if is_executable(file_.get_location()):
-                return get_executable_menu_items(file_, self._menu_exe_activate_cb, terminal_name=self._get_terminal_name())
+                return get_executable_menu_items(
+                    file_, self._menu_exe_activate_cb, terminal_name=self._get_terminal_name()
+                )
 
             return []
 


### PR DESCRIPTION
This patch fixes the extension crashing Nautilus on Fedora 43 (Rawhide) with Nautilus 49.2 and Python 3.14.

Changes:
- Wrap environment detection in try/except to prevent RuntimeError crashes
- Add fail-open GSettings loading with fallback to default terminal 
- Add support for Nautilus API version 4.1 (in addition to 4.0)
- Initialize FileManager to None to prevent NameError
- Add null-safe GSettings access in OpenAnyTerminalExtension
- Clean environment variables (LD_LIBRARY_PATH, LD_PRELOAD) to avoid Flatpak library conflicts when launching terminals
- Updated README with Note for Flatpak dconf-editor users

The extension now fails gracefully instead of crashing Nautilus when:
- GSettings schema is not found or fails to compile
- Environment detection fails
- File manager cannot be imported

Tested on: Fedora 43, Nautilus 49.2, Python 3.14

DISCLAIMER: This change was made using Claude code. I have reviewed every line but I lack experience with gnome extension APIs. To me the changes look reasonable and make sense. Also the changes are currently working for me in my laptop.