### PR TITLE
fix: open Ghostty in the correct working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following terminal emulators are fully supported. PRs for other terminals ar
 - `deepin-terminal`
 - `ddterm`
 - `foot`/`footclient`
-- `ghostty`
+- `ghostty` (requires `gtk-single-instance = false` in the Ghostty config, otherwise the working directory flag is ignored by a running instance)
 - `gnome-terminal`
 - `guake`
 - `kermit`

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -209,6 +209,14 @@ def parse_custom_command(command: str, data: str | list[str]) -> list[str]:
     return shlex.split(command.replace("%s", shlex.join(data)))
 
 
+def _append_workdir_args(cmd: list[str], path: str, data: Terminal) -> None:
+    if data.workdir_value_inline:
+        cmd.extend(f"{arg}={path}" for arg in data.workdir_arguments)
+    else:
+        cmd.extend(data.workdir_arguments)
+        cmd.append(path)
+
+
 def run_command_in_terminal(command: list[str], *, cwd: str | None = None):
     if terminal == "custom":
         cmd = parse_custom_command(custom_remote_command, command)
@@ -218,11 +226,7 @@ def run_command_in_terminal(command: list[str], *, cwd: str | None = None):
         if terminal == "ptyxis" and (command and command[0] == "ssh"):
             del cmd[1]
         if cwd and terminal_data.workdir_arguments:
-            if terminal_data.workdir_value_inline:
-                cmd.extend(f"{arg}={cwd}" for arg in terminal_data.workdir_arguments)
-            else:
-                cmd.extend(terminal_data.workdir_arguments)
-                cmd.append(cwd)
+            _append_workdir_args(cmd, cwd, terminal_data)
         cmd.extend(terminal_data.command_arguments)
         cmd.extend(command)
 
@@ -285,11 +289,7 @@ def open_local_terminal_in_uri(uri: str):
     if terminal == "custom":
         cmd = parse_custom_command(custom_local_command, filename)
     elif filename and terminal_data.workdir_arguments:
-        if terminal_data.workdir_value_inline:
-            cmd.extend(f"{arg}={filename}" for arg in terminal_data.workdir_arguments)
-        else:
-            cmd.extend(terminal_data.workdir_arguments)
-            cmd.append(filename)
+        _append_workdir_args(cmd, filename, terminal_data)
 
     Popen(cmd, cwd=filename)  # pylint: disable=consider-using-with
 

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -37,6 +37,7 @@ class Terminal:
 
     name: str
     workdir_arguments: Optional[list[str]] = None
+    workdir_value_inline: bool = False
     new_tab_arguments: Optional[list[str]] = None
     new_window_arguments: Optional[list[str]] = None
     command_arguments: list[str] = field(default_factory=lambda: ["-e"])
@@ -88,7 +89,7 @@ TERMINALS = {
     ),
     "foot": Terminal("Foot"),
     "footclient": Terminal("FootClient"),
-    "ghostty": Terminal("Ghostty"),
+    "ghostty": Terminal("Ghostty", workdir_arguments=["--working-directory"], workdir_value_inline=True),
     "gnome-terminal": Terminal("Terminal", new_tab_arguments=["--tab"], command_arguments=["--"]),
     "guake": Terminal("Guake", workdir_arguments=["--show", "--new-tab"]),
     "kermit": Terminal("Kermit"),
@@ -217,8 +218,11 @@ def run_command_in_terminal(command: list[str], *, cwd: str | None = None):
         if terminal == "ptyxis" and (command and command[0] == "ssh"):
             del cmd[1]
         if cwd and terminal_data.workdir_arguments:
-            cmd.extend(terminal_data.workdir_arguments)
-            cmd.append(cwd)
+            if terminal_data.workdir_value_inline:
+                cmd.extend(f"{arg}={cwd}" for arg in terminal_data.workdir_arguments)
+            else:
+                cmd.extend(terminal_data.workdir_arguments)
+                cmd.append(cwd)
         cmd.extend(terminal_data.command_arguments)
         cmd.extend(command)
 
@@ -281,8 +285,11 @@ def open_local_terminal_in_uri(uri: str):
     if terminal == "custom":
         cmd = parse_custom_command(custom_local_command, filename)
     elif filename and terminal_data.workdir_arguments:
-        cmd.extend(terminal_data.workdir_arguments)
-        cmd.append(filename)
+        if terminal_data.workdir_value_inline:
+            cmd.extend(f"{arg}={filename}" for arg in terminal_data.workdir_arguments)
+        else:
+            cmd.extend(terminal_data.workdir_arguments)
+            cmd.append(filename)
 
     Popen(cmd, cwd=filename)  # pylint: disable=consider-using-with
 

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -210,6 +210,8 @@ def parse_custom_command(command: str, data: str | list[str]) -> list[str]:
 
 
 def _append_workdir_args(cmd: list[str], path: str, data: Terminal) -> None:
+    if not data.workdir_arguments:
+        return
     if data.workdir_value_inline:
         cmd.extend(f"{arg}={path}" for arg in data.workdir_arguments)
     else:


### PR DESCRIPTION
Related to #287.

## Summary

- Ghostty requires `--working-directory` as a single `key=value` argument (e.g. `--working-directory=/path`), unlike most terminals that accept it as two separate args. Without this, the flag is silently ignored and Ghostty always opens in `$HOME`.
- Adds a `workdir_value_inline: bool = False` field to the `Terminal` dataclass. It defaults to `False`, so all existing terminals are completely unaffected.
- Applies the inline format in both `open_local_terminal_in_uri` and `run_command_in_terminal` (the latter covers the admin `sudo -s` path).
- Documents the `gtk-single-instance = false` Ghostty config requirement in the README — without it, a running Ghostty instance ignores `--working-directory` entirely.

Closes #287