### PR TITLE
Allow connecting to remote hosts with Fish shell

### DIFF
--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -250,7 +250,7 @@ def ssh_command_from_uri(uri: str, *, is_directory: bool):
 
     target = shlex.quote(unquote(result.path))
     if is_directory:
-        cmd.extend(["cd", target, ";", "exec", "${SHELL:-/bin/sh}", "-l"])
+        cmd.extend(["cd", target, ";", "exec", "$SHELL", "-l"])
     else:
         cmd.extend(["exec", target])
 


### PR DESCRIPTION
Reverts Stunkymonkey/nautilus-open-any-terminal#253

That patch broke integration when the default `$SHELL` in a remote host is [fish](https://fishshell.com/). That shell has a different syntax for default variables:

```shell
ssh -t example.com cd /example ';' exec '${SHELL:-/bin/sh}' -l
fish: ${ is not a valid variable in fish.
cd /example ; exec ${SHELL:-/bin/sh} -l
                    ^
Connection to example.com closed.
```

If someone gets the problem that #253 was trying to fix, the appropriate fix is to add `$SHELL` as a default environment variable in the remote host. For example, adding `SHELL=/bin/sh` to the `.~/.profile` file.