### PR TITLE
Fix for opening terminal in sftp / remote urls #299

### DIFF
--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -579,7 +579,7 @@ class OpenAnyTerminalExtension(GObject.GObject, FileManager.MenuProvider):
         if remote:
             open_remote_terminal_in_uri(file_.get_uri())
         else:
-            if file_.get_uri_scheme() == "smb":
+            if file_.get_uri_scheme() not in {"file","localtest"}:
                 file_uri = "file://" + quote(file_.get_location().get_path())
             else:
                 file_uri = file_.get_uri()


### PR DESCRIPTION
Most schemas are remote or won't work as a plain file path. 
https://wiki.gnome.org/Projects(2f)gvfs(2f)schemes.html

issue https://github.com/Stunkymonkey/nautilus-open-any-terminal/issues/299