### PR TITLE
fix: use +new-window for Ghostty

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following terminal emulators are fully supported. PRs for other terminals ar
 - `deepin-terminal`
 - `ddterm`
 - `foot`/`footclient`
-- `ghostty` (requires `gtk-single-instance = false` in the Ghostty config, otherwise the working directory flag is ignored by a running instance)
+- `ghostty`
 - `gnome-terminal`
 - `guake`
 - `kermit`

--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
@@ -89,7 +89,12 @@ TERMINALS = {
     ),
     "foot": Terminal("Foot"),
     "footclient": Terminal("FootClient"),
-    "ghostty": Terminal("Ghostty", workdir_arguments=["--working-directory"], workdir_value_inline=True),
+    "ghostty": Terminal(
+        "Ghostty",
+        workdir_arguments=["--working-directory"],
+        workdir_value_inline=True,
+        new_window_arguments=["+new-window"],
+    ),
     "gnome-terminal": Terminal("Terminal", new_tab_arguments=["--tab"], command_arguments=["--"]),
     "guake": Terminal("Guake", workdir_arguments=["--show", "--new-tab"]),
     "kermit": Terminal("Kermit"),


### PR DESCRIPTION
Follow-up to #288

PR #288 added support for the `--working-directory=<path>` argument in Ghostty, but required users to set `gtk-single-instance = false` because a running Ghostty instance ignored the working-directory option.

This PR uses the Ghostty `+new-window` command to allow the requested working directory to be passed when opening a new window, regardless of the `gtk-single-instance` configuration.